### PR TITLE
Quick hack on the example for web rendering

### DIFF
--- a/example/server.ts
+++ b/example/server.ts
@@ -13,7 +13,12 @@ app.use(async (context, next) => {
     await context.send({ root: join(Deno.cwd(), "../libs/openscad") });
     return;
   }
-
+  if(context.request.url.pathname.startsWith("/three")){
+    context.request.url.pathname = context.request.url.pathname.substring("/three".length);
+    await context.send({ root: join(Deno.cwd(), "../node_modules/three") });
+    return;
+  }
+  
   try {
     await context.send({ root: join(Deno.cwd(), "www"), index: "index.html" });
   } catch {

--- a/example/www/index.html
+++ b/example/www/index.html
@@ -1,6 +1,28 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <style>
+        .resize {
+            width: 2px;
+            padding: 0px;
+            border: 4px;
+            border-color: white;
+            border-style: solid;
+            background-color: cadetblue;
+            cursor: ew-resize;
+            flex: 0 0 auto;
+        }
+        #mainApp {
+            display: flex;
+            height: 100%;
+        }
+        #editor {
+            padding-right: 7px;
+        }
+        body {
+            overflow: hidden;
+        }
+    </style>
     <script type="importmap">
         {
             "imports": {
@@ -19,7 +41,6 @@
         import * as THREE from 'three'
         import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
         import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
-        import Stats from 'three/examples/jsm/libs/stats.module'
 
         function downloadFile(blob, fileName) {
             const link = document.createElement('a');
@@ -80,7 +101,8 @@
         renderer.outputEncoding = THREE.sRGBEncoding
         
         renderer.setSize(window.innerWidth*.8, window.innerHeight)
-        document.getElementById("render").appendChild(renderer.domElement)
+        document.getElementById("renderPane").appendChild(renderer.domElement)
+        
 
         const controls = new OrbitControls(camera, renderer.domElement)
         controls.enableDamping = true
@@ -92,14 +114,18 @@
 
         window.addEventListener('resize', onWindowResize, false)
         function onWindowResize() {
-            camera.aspect = window.innerWidth*.8 / window.innerHeight
+            // Get the width of the render view
+            var width = document.getElementById("renderPane").style.width;
+            // Cut off the 'px'
+            width = width.substring(0,width.length-2)
+
+            camera.aspect = width / window.innerHeight
             camera.updateProjectionMatrix()
-            renderer.setSize(window.innerWidth*.8, window.innerHeight)
+            renderer.setSize(width, window.innerHeight)
+            document.getElementById("mainApp").style.height = (window.innerHeight) + 'px'
             render()
         }
 
-        const stats = Stats()
-        document.body.appendChild(stats.dom)
 
         function animate() {
             requestAnimationFrame(animate)
@@ -107,8 +133,6 @@
             controls.update()
 
             render()
-
-            stats.update()
         }
 
         function render() {
@@ -126,15 +150,55 @@
         document.getElementById("download-button").onclick = function() {
             downloadFile(new Blob([output], { type: "application/octet-stream" }), "OpenSCAD.stl");
         }
+
+
+        var resizeBar = "";
+        function resizeMouseDown(target) {
+            console.log(event);
+            resizeBar = event.target;
+        }
+
+        document.querySelectorAll(".resize").forEach(function(e) {
+            console.log(e);
+            e.addEventListener('mousedown',resizeMouseDown, true);
+        })
+
+        document.addEventListener('mousemove', function(e) {
+            // Exit if no bar selected
+            if (resizeBar == "") {
+                return false;
+            }
+            var resizeTarget = document.getElementById(resizeBar.attributes.target.value);
+
+            // Resize right side item for now, we'll make it smarter later
+            var resizeWidth = window.innerWidth - e.clientX;
+
+            resizeTarget.style.width = (Math.min(window.innerWidth - 120, resizeWidth)) + 'px';
+
+            onWindowResize();
+        });
+
+        document.addEventListener('mouseup', function(e) {
+            resizeBar = "";
+        });
+
+        // Set default sizing
+        document.getElementById("renderPane").style.width = (window.innerWidth*.8) + 'px'
+        document.getElementById("mainApp").style.height = (window.innerHeight) + 'px'
+
+
     </script>
-    <div style="width: 100%;overflow:auto;display: flex; flex-flow: column; height: 100%;flex-direction: row;align-items: stretch;">
-        <div style="float:left; width: 80%" id="render">
-        </div>
-        <div style="float:right;flex-grow : 1;">
+    <div id="mainApp">
+        <div id="editor" style="background-color: bisque; flex: 1 1 auto">
+            <!-- This will eventually be a toolbar -->
             <a id="render-button" href="#">Render</a>
             <a id="download-button" href="#">Download</a>
-            <textarea name="data" id="input" style="width: 95%; height:95%">cube(2);</textarea>
+            <br>
+            
+            <textarea name="data" id="input" style="width: 100%; height:95%;">cube(2);</textarea>
         </div>
+        <div class="resize" id="resizeEditor" target="renderPane" direction="horazontal" onmousedown="resizeMouseDown('resizeEditor')"></div>
+        <div id="renderPane" style="background-color:aqua;flex: 0 1 auto"></div>
     </div>
 </body>
 

--- a/example/www/index.html
+++ b/example/www/index.html
@@ -44,6 +44,7 @@
         var output;
 
         async function generateMesh() {
+            // Quick testing shows that this seems to be the way. Re-using instance errors when running "callMain"
             var instance = await OpenScad({ noInitialRun: true });
             instance.FS.writeFile("/input2.scad", document.getElementById("input").value);
             instance.callMain(["/input2.scad", "-o", "cube2.stl"]);
@@ -118,7 +119,7 @@
 
         document.getElementById("render-button").onclick = async function() {
             scene.remove(mesh);
-            mesh = mesh = await generateMesh();
+            mesh = await generateMesh();
             scene.add(mesh)
         }
 

--- a/example/www/index.html
+++ b/example/www/index.html
@@ -51,15 +51,22 @@
             link.remove();
         };
 
-        const material = new THREE.MeshPhysicalMaterial({
-            color: 0x004400,
-            metalness: 0.25,
-            roughness: 0.1,
-            opacity: 0,
-            transparent: false,
-            transmission: 0.8,
-            clearcoat: 1.0,
-            clearcoatRoughness: 0.25
+        // const material = new THREE.MeshPhysicalMaterial({
+        //     color: 0x004400,
+        //     metalness: 0.25,
+        //     roughness: 0.1,
+        //     opacity: 0,
+        //     transparent: false,
+        //     transmission: 0.8,
+        //     clearcoat: 1.0,
+        //     clearcoatRoughness: 0.25
+        // })
+
+        const material = new THREE.MeshStandardMaterial({
+            color: 0x009900,
+            flatShading: true,
+            metalness: 0.1,
+            roughness: 0.5,
         })
 
         var output;
@@ -82,11 +89,7 @@
         const scene = new THREE.Scene()
         scene.add(new THREE.AxesHelper(5))
 
-        const light = new THREE.SpotLight()
-        light.position.set(15, 15, 15)
-        scene.add(light)
-
-        const light2 = new THREE.AmbientLight()
+        const light2 = new THREE.AmbientLight(0xffffff, 0.5)
         scene.add(light2)
 
         const camera = new THREE.PerspectiveCamera(
@@ -96,6 +99,11 @@
             1000
         )
         camera.position.z = 3
+
+        const light = new THREE.PointLight(0xffffff, 1.5)
+        light.position.set(1, 1, 2)
+        camera.add(light)
+        scene.add(camera)
 
         const renderer = new THREE.WebGLRenderer()
         renderer.outputEncoding = THREE.sRGBEncoding
@@ -125,7 +133,6 @@
             document.getElementById("mainApp").style.height = (window.innerHeight) + 'px'
             render()
         }
-
 
         function animate() {
             requestAnimationFrame(animate)

--- a/example/www/index.html
+++ b/example/www/index.html
@@ -1,9 +1,25 @@
 <!DOCTYPE html>
 <html>
-
-<body>
+<head>
+    <script type="importmap">
+        {
+            "imports": {
+                "openscad": "/openscad.js",
+                "three": "/three/build/three.module.js",
+                "three/examples/jsm/loaders/STLLoader": "/three/examples/jsm/loaders/STLLoader.js",
+                "three/examples/jsm/controls/OrbitControls": "/three/examples/jsm/controls/OrbitControls.js",
+                "three/examples/jsm/libs/stats.module": "/three/examples/jsm/libs/stats.module.js"
+            }
+        }
+    </script>
+</head>
+<body style="margin:0">
     <script type="module">
-        import OpenScad from "./openscad.js";
+        import OpenScad from "openscad";
+        import * as THREE from 'three'
+        import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+        import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
+        import Stats from 'three/examples/jsm/libs/stats.module'
 
         function downloadFile(blob, fileName) {
             const link = document.createElement('a');
@@ -14,14 +30,111 @@
             link.remove();
         };
 
-        const instance = await OpenScad({ noInitialRun: true });
+        const material = new THREE.MeshPhysicalMaterial({
+            color: 0x004400,
+            metalness: 0.25,
+            roughness: 0.1,
+            opacity: 0,
+            transparent: false,
+            transmission: 0.8,
+            clearcoat: 1.0,
+            clearcoatRoughness: 0.25
+        })
 
-        instance.FS.writeFile("/input.scad", `cube(10);`);
-        instance.callMain(["/input.scad", "-o", "cube.stl"]);
-        const output = instance.FS.readFile("/cube.stl");
+        var output;
 
-        downloadFile(new Blob([output], { type: "application/octet-stream" }), "cube.stl");
+        async function generateMesh() {
+            var instance = await OpenScad({ noInitialRun: true });
+            instance.FS.writeFile("/input2.scad", document.getElementById("input").value);
+            instance.callMain(["/input2.scad", "-o", "cube2.stl"]);
+            output = instance.FS.readFile("/cube2.stl");
+
+            var t = loader.parse(output.buffer);
+            var outMesh = new THREE.Mesh(t, material);
+
+            return outMesh;
+
+        }
+
+        // Three.js tutorial https://sbcode.net/threejs/loaders-stl/
+        const scene = new THREE.Scene()
+        scene.add(new THREE.AxesHelper(5))
+
+        const light = new THREE.SpotLight()
+        light.position.set(15, 15, 15)
+        scene.add(light)
+
+        const light2 = new THREE.AmbientLight()
+        scene.add(light2)
+
+        const camera = new THREE.PerspectiveCamera(
+            75,
+            window.innerWidth*.8 / window.innerHeight,
+            0.1,
+            1000
+        )
+        camera.position.z = 3
+
+        const renderer = new THREE.WebGLRenderer()
+        renderer.outputEncoding = THREE.sRGBEncoding
+        
+        renderer.setSize(window.innerWidth*.8, window.innerHeight)
+        document.getElementById("render").appendChild(renderer.domElement)
+
+        const controls = new OrbitControls(camera, renderer.domElement)
+        controls.enableDamping = true
+
+        const loader = new STLLoader()
+        var mesh = await generateMesh();
+
+        scene.add(mesh);
+
+        window.addEventListener('resize', onWindowResize, false)
+        function onWindowResize() {
+            camera.aspect = window.innerWidth*.8 / window.innerHeight
+            camera.updateProjectionMatrix()
+            renderer.setSize(window.innerWidth*.8, window.innerHeight)
+            render()
+        }
+
+        const stats = Stats()
+        document.body.appendChild(stats.dom)
+
+        function animate() {
+            requestAnimationFrame(animate)
+
+            controls.update()
+
+            render()
+
+            stats.update()
+        }
+
+        function render() {
+            renderer.render(scene, camera)
+        }
+
+        animate()
+
+        document.getElementById("render-button").onclick = async function() {
+            scene.remove(mesh);
+            mesh = mesh = await generateMesh();
+            scene.add(mesh)
+        }
+
+        document.getElementById("download-button").onclick = function() {
+            downloadFile(new Blob([output], { type: "application/octet-stream" }), "OpenSCAD.stl");
+        }
     </script>
+    <div style="width: 100%;overflow:auto;display: flex; flex-flow: column; height: 100%;flex-direction: row;align-items: stretch;">
+        <div style="float:left; width: 80%" id="render">
+        </div>
+        <div style="float:right;flex-grow : 1;">
+            <a id="render-button" href="#">Render</a>
+            <a id="download-button" href="#">Download</a>
+            <textarea name="data" id="input" style="width: 95%; height:95%">cube(2);</textarea>
+        </div>
+    </div>
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "openscad-wasm",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "three": "^0.139.2"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.139.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
+      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
+    }
+  },
+  "dependencies": {
+    "three": {
+      "version": "0.139.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
+      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "three": "^0.139.2"
+  }
+}


### PR DESCRIPTION
Still needs a bit of work to optimize and make cleaner. This allows a user of the web example to render the generated model and download it. 

Additionally I added a textbox so users can edit in the browser and render as they go. 

A JS linter will be needed to make this useful and not just "not work" on bad scad files