### PR TITLE
Update to latest dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ res
 !res/fonts
 *.make
 .oci.*
+.DS_Store

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -11,7 +11,6 @@ RUN --mount=type=cache,target=/var/cache/apt \
     --mount=type=cache,target=/root/.cache/pip \
     apt update && \
     apt install -qqy \
-      autoconf \
       automake \
       autopoint \
       bison \
@@ -41,6 +40,16 @@ ENV MESON_BUILD_TYPE=${MESON_BUILD_TYPE}
 ENV CFLAGS="${EMSCRIPTEN_FLAGS}"
 ENV CXXFLAGS="${EMSCRIPTEN_FLAGS}"
 ENV LDFLAGS="${EMSCRIPTEN_FLAGS}"
+# Build autoconf from source since we require 2.72
+WORKDIR /home/ubuntu
+RUN wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.72.tar.xz
+RUN tar -xf autoconf-2.72.tar.xz
+RUN ls -al autoconf-2.72/
+WORKDIR /home/ubuntu/autoconf-2.72/
+RUN ./configure
+RUN make
+RUN sudo make install
+WORKDIR /home/ubuntu
 
 
 FROM builder AS boost
@@ -94,7 +103,6 @@ RUN emcmake cmake \
         -G Ninja && \
     cmake --build ../build --parallel && \
     cmake --install ../build
-
 
 FROM builder AS libffi
 COPY libffi .

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ DOCKER_OCI_BASE ?= .oci.wasm-base$(VARIANT)-$(ENV)
 
 # Use the arm64 version of the emscripten sdk if running on an arm64 machine, as the amd64 image would crash QEMU in a couple of places.
 # See latest version in https://hub.docker.com/r/emscripten/emsdk/tags
-EMSCRIPTEN_VERSION ?= 3.1.74
+EMSCRIPTEN_VERSION ?= 4.0.10
 UNAME_MACHINE := $(shell uname -m)
 ifeq ($(UNAME_MACHINE),arm64)
     EMSCRIPTEN_SDK_TAG=emscripten/emsdk:$(EMSCRIPTEN_VERSION)-arm64
@@ -71,9 +71,9 @@ build/openscad.wasm.js: .image$(VARIANT)-$(ENV).make
 	mkdir -p build
 	docker rm -f tmpcpy
 	docker run --name tmpcpy $(DOCKER_TAG_OPENSCAD)
-	docker cp tmpcpy:/build/openscad.js build/openscad.wasm.js
-	docker cp tmpcpy:/build/openscad.wasm build/
-	docker cp tmpcpy:/build/openscad.wasm.map build/ || true
+	docker cp tmpcpy:/home/build/openscad.js build/openscad.wasm.js
+	docker cp tmpcpy:/home/build/openscad.wasm build/
+	docker cp tmpcpy:/home/build/openscad.wasm.map build/ || true
 	docker rm tmpcpy
 
 .image$(VARIANT)-$(ENV).make: .base-image$(VARIANT)-$(ENV).make Dockerfile

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ make build
 make ENV=Debug build
 ```
 
+## MacOS
+
+On MacOS, the version of Make that ships with the OS (3.81) is not compatible with this makefile, so you'll need to install a modern version of make and use that instead.
+
+For instance, with homebrew:
+
+`brew install gmake`
+
+Depending on your PATH configuration, you may need to use `gmake` instead of `make` when running setup commands.
+
 ## Usage
 
 There is an example project in the example folder. Run it using:


### PR DESCRIPTION
I attempted to build this on a mac running the latest tools and it failed in various ways - this PR updates emscripten and autoconf, along with some minor changes that I assume are related to these dependency updates, which results in being able to build successfully again.

- Update to emscripten 4.0.10
- Build autoconf 2.72 from source since it is required but not available in apt
- Add MacOS instructions to README
- Ignore .DS_Store

The main thing that looks a little funny to me is the change of the location of the build dir in the openscad-wasm image. Perhaps the default dir of a base image changed at some point? FWIW everything is built into `/home/ubuntu` so `cmake --build ../build --parallel` in `Dockerfile` results in the build dir being `/home/build` instead of `/build`.

I only tested this on mac.